### PR TITLE
Added custom rel support for rel=me

### DIFF
--- a/config/links.json
+++ b/config/links.json
@@ -25,6 +25,7 @@
     "text": "Another Example",
     "hoverText": "Visit Another Example",
     "logo": "https://openmoji.org/data/color/svg/E042.svg",
+    "rel": "me",
     "color": "#ff0000"
   },
   {

--- a/script.js
+++ b/script.js
@@ -86,8 +86,14 @@ document.addEventListener("DOMContentLoaded", function () {
       linksData.forEach((link) => {
         const linkButton = document.createElement("a");
         linkButton.href = link.url;
-        linkButton.rel = "noopener";
         linkButton.classList.add("link-button");
+
+        if (link.rel) {
+          linkButton.rel = link.rel;
+        } 
+        else {
+          linkButton.rel = "noopener";
+        }
 
         if (link.color) {
           linkButton.style.backgroundColor = link.color;


### PR DESCRIPTION
This allows users to specify a rel property in the JSON, primarily added for rel=me, this still defaults to noopener

example config:
```json
{
  "url": "https://another-example.local",
  "text": "Another Example",
  "hoverText": "Visit Another Example",
  "logo": "https://openmoji.org/data/color/svg/E042.svg",
  "rel": "me",
  "color": "#ff0000"
}
```

Output element:
```HTML
<a href="https://another-example.local" class="link-button" rel="me" title="Visit Another Example"
    aria-label="Another Example" style="background-color: rgb(255, 0, 0);"><img
        src="https://openmoji.org/data/color/svg/E042.svg" alt="Another Example"><span>Another Example</span></a>
```