### PR TITLE
Add pre-rendering to fix issues with SEO and clients with noJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ OpenLinkway is a simple web application that allows you to create and customise 
 
 🍦 Vanilla JS: OpenLinkway is built using only vanilla JavaScript, avoiding the use of any frameworks or libraries. This choice ensures simplicity and eliminates dependencies.
 
-💻 Client-side Rendering: All rendering is done in the user's browser without the need for server-side code. This approach allows for minimal running costs, potentially making it feasible to host OpenLinkway for free or at very low cost.
-
 ✨ Easy customisation: With OpenLinkway, users can easily customise the appearance of their OpenLinkway page by editing configuration files. This flexibility enables users to create a personalised collection of links that aligns with their preferences and branding.
 
 📚 Documentation: OpenLinkway strives to provide comprehensive documentation to assist users in setting up and configuring their OpenLinkway page. This ensures a smooth and hassle-free experience.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ OpenLinkway is a simple web application that allows you to create and customise 
 
 👩‍💻 No Coding Required: The primary goal of OpenLinkway is to eliminate the need for users to write any code. Instead, users can configure OpenLinkway through easily editable configuration files.
 
+💻 Flexible Rendering: OpenLinkway supports both client-side and pre-rendering, allowing you to choose the best approach for your needs. Both options can be hosted with minimal running costs, potentially enabling free or very low-cost hosting.
+
 🍦 Vanilla JS: OpenLinkway is built using only vanilla JavaScript, avoiding the use of any frameworks or libraries. This choice ensures simplicity and eliminates dependencies.
 
 ✨ Easy customisation: With OpenLinkway, users can easily customise the appearance of their OpenLinkway page by editing configuration files. This flexibility enables users to create a personalised collection of links that aligns with their preferences and branding.
@@ -125,3 +127,25 @@ Example usage:
     ]}
 }
 ```
+
+
+### 4. (Optional, but recommended) Pre-render the site for improved SEO and initial load times
+Pre-rendering generates static HTML files that can be served directly to users, improving SEO and perceived load times. To pre-render your OpenLinkway site, follow these steps:
+
+#### Install dependencies: 
+Make sure you have npm and Python installed on your system. These are typically provided by Cloudflare Pages and other static site hosts.
+
+#### Run the pre-render script: 
+
+Execute the following command in your project directory (for Cloudflare pages set this as your Build command):
+
+```Bash
+npm install puppeteer fs-extra && nohup python3 -m http.server & node build.js && pkill python3
+```
+
+This command will install the necessary packages, start a local web server, run the pre-rendering script (build.js), and then stop the web server.
+
+#### Deploy the pre-rendered files: 
+The pre-rendering process will generate a build directory containing the static HTML files. Deploy this directory to your hosting provider. (for Cloudflare pages set your Build output directory to `build`)
+
+Pre-rendering can significantly improve the performance and visibility of your OpenLinkway site, especially for users with slower connections or search engine crawlers.

--- a/build.js
+++ b/build.js
@@ -1,0 +1,39 @@
+const puppeteer = require('puppeteer');
+const fs = require('fs-extra');
+const path = require('path');
+
+async function preRender() {
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+
+    // Load webpage
+    await page.goto('http://0.0.0.0:8000/', { waitUntil: 'networkidle2' });
+
+
+    // Get all the links to assets (CSS, JavaScript, images, etc.)
+    const assets = await page.evaluate(() => {
+        const links = Array.from(document.querySelectorAll('link[rel="stylesheet"], script[src]'));
+        const images = Array.from(document.querySelectorAll('img'));
+        return [
+            ...links.map(link => link.href || link.src),
+            ...images.map(img => img.src)
+        ];
+    });
+
+    // Create the build directory if it doesn't exist
+    const buildDir = path.resolve(__dirname, 'build');
+    await fs.ensureDir(buildDir);
+
+    // Save the rendered HTML
+    const html = await page.content();
+    await fs.writeFile(path.join(buildDir, 'index.html'), html);
+
+    // Copy styles.css and assets folder to build directory
+    await fs.copy('styles.css', path.join(buildDir, 'styles.css'));
+    await fs.copy('script.js', path.join(buildDir, 'script.js'));
+    await fs.copy('assets', path.join(buildDir, 'assets'));
+
+    await browser.close();
+}
+
+preRender();

--- a/build.js
+++ b/build.js
@@ -31,7 +31,9 @@ async function preRender() {
     // Copy styles.css and assets folder to build directory
     await fs.copy('styles.css', path.join(buildDir, 'styles.css'));
     await fs.copy('script.js', path.join(buildDir, 'script.js'));
+    await fs.copy('config', path.join(buildDir, 'config'));
     await fs.copy('assets', path.join(buildDir, 'assets'));
+    await fs.copy('LICENSE.md', path.join(buildDir, 'LICENSE.md'));
 
     await browser.close();
 }

--- a/build.js
+++ b/build.js
@@ -26,7 +26,11 @@ async function preRender() {
 
     // Save the rendered HTML
     const html = await page.content();
-    await fs.writeFile(path.join(buildDir, 'index.html'), html);
+
+    // Add the "rendered" tag to the HTML content
+    const modifiedHtml = html.replace(/<html[^>]*>/, (match) => match.replace('>', ' rendered>'));
+
+    await fs.writeFile(path.join(buildDir, 'index.html'), modifiedHtml);
 
     // Copy styles.css and assets folder to build directory
     await fs.copy('styles.css', path.join(buildDir, 'styles.css'));

--- a/script.js
+++ b/script.js
@@ -1,190 +1,192 @@
 document.addEventListener("DOMContentLoaded", function () {
-  const logoContainer = document.getElementById("logo-container");
-  const linksContainer = document.getElementById("links-container");
-  const bgContainer = document.getElementById("bg-container");
-  const footerBar = document.getElementById("footer-bar");
-  const headerBar = document.getElementById("header-bar");
-  const metaDescription = document.querySelector('meta[name="description"]');
+  if (!document.documentElement.hasAttribute('rendered')) {
+    const logoContainer = document.getElementById("logo-container");
+    const linksContainer = document.getElementById("links-container");
+    const bgContainer = document.getElementById("bg-container");
+    const footerBar = document.getElementById("footer-bar");
+    const headerBar = document.getElementById("header-bar");
+    const metaDescription = document.querySelector('meta[name="description"]');
 
-  // Generate a unique query parameter 
-  const timestamp = Date.now();
+    // Generate a unique query parameter 
+    const timestamp = Date.now();
 
-  const linksPromise = fetch(`config/links.json?t=${timestamp}`)
-    .then((response) => {
-      if (response.ok) {
-        return response.json();
-      } else {
-        console.error("Error fetching links:", response.status);
+    const linksPromise = fetch(`config/links.json?t=${timestamp}`)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          console.error("Error fetching links:", response.status);
+          return []; // Provide an empty array as a fallback
+        }
+      })
+      .catch((error) => {
+        console.error("Error fetching links:", error);
         return []; // Provide an empty array as a fallback
-      }
-    })
-    .catch((error) => {
-      console.error("Error fetching links:", error);
-      return []; // Provide an empty array as a fallback
-    });
-
-  const pagePromise = fetch(`config/page.json?t=${timestamp}`)
-    .then((response) => {
-      if (response.ok) {
-        return response.json();
-      } else {
-        console.error("Error fetching page configuration:", response.status);
-        return {}; // Provide an empty object as a fallback
-      }
-    })
-    .catch((error) => {
-      console.error("Error fetching page configuration:", error);
-      return {}; // Provide an empty object as a fallback
-    });
-
-  const barsPromise = fetch(`config/bars.json?t=${timestamp}`)
-    .then((response) => {
-      if (response.ok) {
-        return response.json();
-      } else {
-        console.error("Error fetching bar configuration:", response.status);
-        return {}; // Provide an empty object as a fallback
-      }
-    })
-    .catch((error) => {
-      console.error("Error fetching bar configuration:", error);
-      return {}; // Provide an empty object as a fallback
-    });
-
-  Promise.all([linksPromise, pagePromise, barsPromise])
-    .then(([linksData, pageData, barsData]) => {
-      // Process the page configuration
-      if (pageData.logo) {
-        const logoImg = document.createElement("img");
-        logoImg.src = pageData.logo;
-        logoImg.alt = "Logo";
-        logoContainer.appendChild(logoImg);
-      }
-
-      if (pageData.backgroundImage) {
-        bgContainer.style.backgroundImage = `url(${pageData.backgroundImage})`;
-      }
-
-      if (pageData.favicon) {
-        const faviconElement = document.getElementById("favicon");
-        faviconElement.href = pageData.favicon;
-      }
-
-      if (pageData.title) {
-        document.title = pageData.title;
-      }
-
-      if (pageData.description) {
-        metaDescription.textContent = pageData.description;
-      }
-
-      if (pageData.language) {
-        document.documentElement.lang = pageData.language;
-      }  
-
-      // Process the links configuration
-      linksData.forEach((link) => {
-        const linkButton = document.createElement("a");
-        linkButton.href = link.url;
-        linkButton.classList.add("link-button");
-
-        if (link.rel) {
-          linkButton.rel = link.rel;
-        } 
-        else {
-          linkButton.rel = "noopener";
-        }
-
-        if (link.color) {
-          linkButton.style.backgroundColor = link.color;
-        }
-
-        if (link.logo) {
-          const logoImg = document.createElement("img");
-          logoImg.src = link.logo;
-          logoImg.alt = link.text;
-          linkButton.appendChild(logoImg);
-        }
-
-        if (link.newTab) {
-          linkButton.target = "_blank"; // Open link in a new tab
-        }
-
-        const spanText = document.createElement("span");
-        spanText.textContent = link.text;
-        linkButton.appendChild(spanText);
-
-        linkButton.setAttribute("title", link.hoverText);
-
-        if (link.fontFamily) {
-          linkButton.style.fontFamily = link.fontFamily;
-        }
-
-        if (link.fontWeight) {
-          linkButton.style.fontWeight = link.fontWeight;
-        }
-
-        if (link.fontSize) {
-          linkButton.style.fontSize = link.fontSize;
-        }
-
-        if (link.textDecoration) {
-          if (link.textDecoration.line) {
-            linkButton.style.textDecorationLine = link.textDecoration.line;
-          }
-          if (link.textDecoration.thickness) {
-            linkButton.style.textDecorationThickness = link.textDecoration.thickness;
-          }
-          if (link.textDecoration.style) {
-            linkButton.style.textDecorationStyle = link.textDecoration.style;
-          }
-          if (link.textDecoration.color) {
-            linkButton.style.textDecorationColor = link.textDecoration.color;
-          }
-        }
-
-        if (link.textColor) {
-          linkButton.style.color = link.textColor;
-        }
-
-        if (link.gradient) {
-          const gradientStyle = generateGradientStyle(link.gradient);
-          linkButton.style.backgroundImage = gradientStyle;
-        }
-
-        linkButton.setAttribute("aria-label", link.text);
-
-        linksContainer.appendChild(linkButton);
       });
 
-      // Process the bars configuration
-      const { header, footer } = barsData;
-
-      if (header) {
-        headerBar.style.backgroundColor = header.color;
-
-        if (header.items) {
-          header.items.forEach((item) => {
-            const headerItem = createBarItem(item);
-            headerBar.appendChild(headerItem);
-          });
+    const pagePromise = fetch(`config/page.json?t=${timestamp}`)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          console.error("Error fetching page configuration:", response.status);
+          return {}; // Provide an empty object as a fallback
         }
-      }
+      })
+      .catch((error) => {
+        console.error("Error fetching page configuration:", error);
+        return {}; // Provide an empty object as a fallback
+      });
 
-      if (footer) {
-        footerBar.style.backgroundColor = footer.color;
-
-        if (footer.items) {
-          footer.items.forEach((item) => {
-            const footerItem = createBarItem(item);
-            footerBar.appendChild(footerItem);
-          });
+    const barsPromise = fetch(`config/bars.json?t=${timestamp}`)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          console.error("Error fetching bar configuration:", response.status);
+          return {}; // Provide an empty object as a fallback
         }
-      }
-    })
-    .catch((error) => {
-      console.error("Error loading configuration:", error);
-    });
+      })
+      .catch((error) => {
+        console.error("Error fetching bar configuration:", error);
+        return {}; // Provide an empty object as a fallback
+      });
+
+    Promise.all([linksPromise, pagePromise, barsPromise])
+      .then(([linksData, pageData, barsData]) => {
+        // Process the page configuration
+        if (pageData.logo) {
+          const logoImg = document.createElement("img");
+          logoImg.src = pageData.logo;
+          logoImg.alt = "Logo";
+          logoContainer.appendChild(logoImg);
+        }
+
+        if (pageData.backgroundImage) {
+          bgContainer.style.backgroundImage = `url(${pageData.backgroundImage})`;
+        }
+
+        if (pageData.favicon) {
+          const faviconElement = document.getElementById("favicon");
+          faviconElement.href = pageData.favicon;
+        }
+
+        if (pageData.title) {
+          document.title = pageData.title;
+        }
+
+        if (pageData.description) {
+          metaDescription.textContent = pageData.description;
+        }
+
+        if (pageData.language) {
+          document.documentElement.lang = pageData.language;
+        }  
+
+        // Process the links configuration
+        linksData.forEach((link) => {
+          const linkButton = document.createElement("a");
+          linkButton.href = link.url;
+          linkButton.classList.add("link-button");
+
+          if (link.rel) {
+            linkButton.rel = link.rel;
+          } 
+          else {
+            linkButton.rel = "noopener";
+          }
+
+          if (link.color) {
+            linkButton.style.backgroundColor = link.color;
+          }
+
+          if (link.logo) {
+            const logoImg = document.createElement("img");
+            logoImg.src = link.logo;
+            logoImg.alt = link.text;
+            linkButton.appendChild(logoImg);
+          }
+
+          if (link.newTab) {
+            linkButton.target = "_blank"; // Open link in a new tab
+          }
+
+          const spanText = document.createElement("span");
+          spanText.textContent = link.text;
+          linkButton.appendChild(spanText);
+
+          linkButton.setAttribute("title", link.hoverText);
+
+          if (link.fontFamily) {
+            linkButton.style.fontFamily = link.fontFamily;
+          }
+
+          if (link.fontWeight) {
+            linkButton.style.fontWeight = link.fontWeight;
+          }
+
+          if (link.fontSize) {
+            linkButton.style.fontSize = link.fontSize;
+          }
+
+          if (link.textDecoration) {
+            if (link.textDecoration.line) {
+              linkButton.style.textDecorationLine = link.textDecoration.line;
+            }
+            if (link.textDecoration.thickness) {
+              linkButton.style.textDecorationThickness = link.textDecoration.thickness;
+            }
+            if (link.textDecoration.style) {
+              linkButton.style.textDecorationStyle = link.textDecoration.style;
+            }
+            if (link.textDecoration.color) {
+              linkButton.style.textDecorationColor = link.textDecoration.color;
+            }
+          }
+
+          if (link.textColor) {
+            linkButton.style.color = link.textColor;
+          }
+
+          if (link.gradient) {
+            const gradientStyle = generateGradientStyle(link.gradient);
+            linkButton.style.backgroundImage = gradientStyle;
+          }
+
+          linkButton.setAttribute("aria-label", link.text);
+
+          linksContainer.appendChild(linkButton);
+        });
+
+        // Process the bars configuration
+        const { header, footer } = barsData;
+
+        if (header) {
+          headerBar.style.backgroundColor = header.color;
+
+          if (header.items) {
+            header.items.forEach((item) => {
+              const headerItem = createBarItem(item);
+              headerBar.appendChild(headerItem);
+            });
+          }
+        }
+
+        if (footer) {
+          footerBar.style.backgroundColor = footer.color;
+
+          if (footer.items) {
+            footer.items.forEach((item) => {
+              const footerItem = createBarItem(item);
+              footerBar.appendChild(footerItem);
+            });
+          }
+        }
+      })
+      .catch((error) => {
+        console.error("Error loading configuration:", error);
+      });
+  }
 });
 
 function generateGradientStyle(gradient) {
@@ -199,26 +201,6 @@ function generateGradientStyle(gradient) {
   }
 
   return "";
-}
-
-function pageRightsize() {
-  const aspectRatio = window.innerWidth / window.innerHeight;
-  const logoContainer = document.getElementById('logo-container');
-  const linksContainer = document.getElementById("links-container");
-  const footer = document.querySelector("footer");
-
-  if (aspectRatio < 1) {
-    linksContainer.style.marginLeft = "10%";
-    linksContainer.style.marginRight = "10%";
-    logoContainer.classList.add("large");
-    footer.classList.add("unpinned"); // Add the "unpinned" class
-    
-  } else {
-    linksContainer.style.marginLeft = "30%";
-    linksContainer.style.marginRight = "30%";
-    footer.classList.remove("unpinned"); // Remove the "unpinned" class
-    logoContainer.classList.remove("large");
-  }
 }
 
 function processMarkdownLinks(text) {
@@ -263,8 +245,26 @@ function createBarItem(item) {
   return barItem;
 }
 
-// Call the function initially when the page loads
+function pageRightsize() {
+  const aspectRatio = window.innerWidth / window.innerHeight;
+  const logoContainer = document.getElementById('logo-container');
+  const linksContainer = document.getElementById("links-container");
+  const footer = document.querySelector("footer");
+
+  if (aspectRatio < 1) {
+    linksContainer.style.marginLeft = "10%";
+    linksContainer.style.marginRight = "10%";
+    logoContainer.classList.add("large");
+    footer.classList.add("unpinned"); // Add the "unpinned" class
+    
+  } else {
+    linksContainer.style.marginLeft = "30%";
+    linksContainer.style.marginRight = "30%";
+    footer.classList.remove("unpinned"); // Remove the "unpinned" class
+    logoContainer.classList.remove("large");
+  }
+}
+
 document.addEventListener("DOMContentLoaded", pageRightsize);
 
-// Call the function whenever the window is resized
 window.addEventListener("resize", pageRightsize);


### PR DESCRIPTION
The build still includes all assets required for client side rendering, however now should work with pre rendering. This fixes #5 

Requirements for pre rendering:
`npm`
`python3`

You can pre render the site by running the command:
`npm install puppeteer fs-extra && nohup python3 -m http.server & node build.js && pkill python3`

This will output the site into the build folder, if using Cloudflare pages please set your `Build output directory` to `build`

This does not break client side rendering any sites preferring to use that do not have to make any changes to config.