### PR TITLE
Add Redirect Function (Cloudflare pages only)

### DIFF
--- a/.github/workflows/Create Release.yaml
+++ b/.github/workflows/Create Release.yaml
@@ -22,7 +22,7 @@ jobs:
           
       - name: Archive Files
         run: |
-          tar -czf OpenLinkway.tar.gz styles.css index.html LICENSE.md build.js Makefile js
+          tar -czf OpenLinkway.tar.gz styles.css index.html LICENSE.md build.js Makefile js _redirects
 
           
       - name: Create Release

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/OpenLinkway https://github.com/StrawbethyMilkshake/OpenLinkway 302

--- a/config/links.json
+++ b/config/links.json
@@ -1,6 +1,7 @@
 [
   {
-    "url": "https://example.local",
+    "url": "https://bsky.app/profile/TestUser",
+    "redirect": "/example",
     "text": "Example",
     "hoverText": "Visit Example",
     "newTab": true,
@@ -22,6 +23,7 @@
   },
   {
     "url": "https://another-example.local",
+    "redirect": "/example2",
     "text": "Another Example",
     "hoverText": "Visit Another Example",
     "logo": "https://openmoji.org/data/color/svg/E042.svg",


### PR DESCRIPTION
## This feature is targeting cloudflare pages users, if you use a different web server you'll need an .htaccess instead file. I may create a conversion function to allow this to function on other web servers

https://developers.cloudflare.com/pages/configuration/redirects/

You can use this by either adding things into the _redirects file in the root, and/or by adding a `redirect` parameter with a value of `/Example` into links.js which will then create [yoursite]/Example which will redirect to the endpoint specified by the button.

### If you do not want a button on the site for it add it to the redirects file following the documentation on cloudflare's website.

### If you want to show a button on the site and have a redirect instead just add a 'redirect' param to links.json